### PR TITLE
fix the response parse bug

### DIFF
--- a/lib/Qiniu/Response.php
+++ b/lib/Qiniu/Response.php
@@ -36,7 +36,7 @@ class Response
     {
         $body_pos = strpos($response, "\r\n\r\n");
         $header_string = substr($response, 0, $body_pos);
-        if ($header_string == 'HTTP/1.1 100 Continue') {
+        if (strpos($header_string, 'HTTP/1.1 100 Continue') !== false) {
             $head_pos = $body_pos + 4;
             $body_pos = strpos($response, "\r\n\r\n", $head_pos);
             $header_string = substr($response, $head_pos, $body_pos - $head_pos);


### PR DESCRIPTION
the parse function error when the response content is
"
HTTP/1.1 100 Continue
Date: Wed, 23 Dec 2015 10:20:46 GMT

(other)
"
